### PR TITLE
ci: add coverage.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dummy
 node_modules
 dist
 coverage
+coverage.txt


### PR DESCRIPTION
https://travis-ci.org/suzuki-shunsuke/gria/builds/399803275

```
⨯ release failed after 0.02s error=git is currently in a dirty state:
?? coverage.txt
Script failed with status 1
```